### PR TITLE
Biomarker table - status badge variant mapping

### DIFF
--- a/src/app/v0/page.tsx
+++ b/src/app/v0/page.tsx
@@ -71,7 +71,7 @@ export default function DesignSystemPage() {
 
 
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-black text-foreground">
       <div className="container mx-auto px-6 py-8">
         <div className="mb-8">
           <h1 className="text-3xl font-bold tracking-tight">Design System</h1>

--- a/src/components/ui/biomarker-table-row.tsx
+++ b/src/components/ui/biomarker-table-row.tsx
@@ -78,19 +78,14 @@ const BiomarkerTableRow: React.FC<BiomarkerTableRowProps> = ({
 
   // Get status badge variant
   const getStatusVariant = (status: string) => {
-    switch (status) {
-      case 'Peak':
-        return 'green';
-      case 'Critical':
-        return 'red';
-      case 'Out Of Range':
-        return 'orange';
-      case 'Normal':
-        return 'blue';
-      default:
-        return 'blue';
+    switch(status.toLowerCase()) {
+      case "peak": return "peak"
+      case "critical": return "critical"
+      case "out of range": return "out_of_range"
+      case "normal": return "normal"
+      default: return "outline"
     }
-  };
+  }
 
 
   // Initialize input value when editing starts

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-caption-1 font-bold transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-bold transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -21,9 +21,9 @@ const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 py-2 px-5 text-caption-1 font-bold",
-        sm: "h-7 py-3 px-6 text-caption-2 font-bold",
-        lg: "h-11 py-1 px-3 text-caption-1 font-bold",
+        default: "h-9 px-4 py-2",
+        sm: "h-7 py-1 px-3 text-xs",
+        lg: "h-11 py-3 px-6 text-xl font-bold",
         icon: "h-9 w-9",
       },
     },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,29 +5,26 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  // Update base class for pill shape and badge-like typography
-  "inline-flex items-center justify-center rounded-full text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-caption-1 font-bold transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost:
-          "hover:bg-accent hover:text-accent-foreground",
-        link:
-          "underline-offset-4 hover:underline text-primary",
+          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-10 px-4 py-2 text-xs",
-        sm: "h-9 px-3 text-xs",
-        lg: "h-11 px-8 text-sm",
-        icon: "h-10 w-10",
+        default: "h-9 py-2 px-5 text-caption-1 font-bold",
+        sm: "h-7 py-3 px-6 text-caption-2 font-bold",
+        lg: "h-11 py-1 px-3 text-caption-1 font-bold",
+        icon: "h-9 w-9",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,26 +5,29 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  // Update base class for pill shape and badge-like typography
+  "inline-flex items-center justify-center rounded-full text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground hover:bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground",
+        link:
+          "underline-offset-4 hover:underline text-primary",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-10 px-4 py-2 text-xs",
+        sm: "h-9 px-3 text-xs",
+        lg: "h-11 px-8 text-sm",
+        icon: "h-10 w-10",
       },
     },
     defaultVariants: {

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,8 +12,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border bg-background px-3 py-1 text-base shadow-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "h-9 w-full rounded-xl bg-background px-3 py-1 text-base shadow-sm transition-all duration-200 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           "hover:border-accent-foreground/20",
           "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted",
           error

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -11,8 +11,8 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          "flex min-h-[60px] w-full rounded-md border bg-background px-3 py-2 text-base shadow-sm transition-all duration-200 placeholder:text-muted-foreground resize-none",
-          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+          "min-h-[60px] w-full rounded-xl bg-background px-3 py-2 text-base shadow-sm transition-all duration-200 placeholder:text-muted-foreground resize-none",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
           "hover:border-accent-foreground/20",
           "disabled:cursor-not-allowed disabled:opacity-50 disabled:bg-muted",
           error


### PR DESCRIPTION
updated to 
The biomarker table now uses the existing badge variants for statuses:
"peak" → peak (green)
"critical" → critical (red)
"out of range" → out_of_range (orange)
"normal" → normal (blue)